### PR TITLE
Ignore incompatible database and finish import with warnings

### DIFF
--- a/pyrekordbox/config.py
+++ b/pyrekordbox/config.py
@@ -131,7 +131,10 @@ def _get_rb6_config(pioneer_prog_dir: str, pioneer_app_dir: str):
     # Read password from app.asar, see
     # https://www.reddit.com/r/Rekordbox/comments/qou6nm/key_to_open_masterdb_file/
     asar_data = read_rekordbox6_asar(conf["install_dir"])
-    match = re.search('pass: ".(.*?)"', asar_data).group(0)
+    match_result = re.search('pass: ".(.*?)"', asar_data)
+    if match_result is None:
+        raise ValueError("Incompatible rekordbox 6 database ignored.")
+    match = match_result.group(0)
     pw = match.replace("pass: ", "").strip('"')
 
     cipher = blowfish.Cipher(pw.encode())
@@ -197,6 +200,8 @@ def update_config(pioneer_install_dir="", pioneer_app_dir=""):
         conf = _get_rb6_config(pioneer_install_dir, pioneer_app_dir)
         __config__["rekordbox6"].update(conf)
     except FileNotFoundError as e:
+        logging.warning(e)
+    except ValueError as e:
         logging.warning(e)
 
 

--- a/pyrekordbox/xml.py
+++ b/pyrekordbox/xml.py
@@ -233,7 +233,7 @@ class AbstractElement(abc.Mapping):
         except KeyError:
             # Convert to str just in case
             value = str(value)
-        self._element.attrib.set(key, value)
+        self._element.attrib[key] = value
 
     def __len__(self):
         """int: The number of attributes of the XML element."""


### PR DESCRIPTION
This allows the library to be used with reduced functionality, for example, RekordboxXML still works.