### PR TITLE
Add new tracks to the Rekordbox 6 database

### DIFF
--- a/docs/source/formats/db6.md
+++ b/docs/source/formats/db6.md
@@ -302,8 +302,8 @@ corresponding ID.
      - Path to the tracks album artwork
      - The path is relative to the Rekordbox database root
    * - `MasterDBID`
-     - The master-ID of the track
-     - Not sure whats the difference to `ID`
+     - The database where the track is stored
+     - Links to `DBID` in the `DjmdProperty` table
    * - `MasterSongID`
      - The master-song-ID of the track
      - Not sure whats the difference to `ID` and `MasterDBID`
@@ -341,7 +341,7 @@ corresponding ID.
      - Date of file creation
      - Format: yyyy-mm-dd; ex.: 2010-08-21
    * - `ContentLink`
-     - ?
+     - Link to the `rb_local_usn` of `TRACK` in `DjmdMenuItems`?
      -
    * - `Tag`
      - My tag value
@@ -413,7 +413,7 @@ corresponding ID.
      - The Rekordbox ID of the file
      -
    * - `DeviceID`
-     - ?
+     - The ID of the DjmdDevice this track is stored on.
      -
    * - `rb_LocalFolderPath`
      - ?

--- a/docs/source/tutorial/db6.md
+++ b/docs/source/tutorial/db6.md
@@ -160,6 +160,34 @@ song = playlist.Songs[0]
 db.remove_from_playlist(playlist, song)
 ````
 
+### Tracks
+
+New tracks can be added to your rekordbox collection by calling the `db.add_content()` method:
+
+```python
+track = db.add_content("/Users/deadmau5/Downloads/Banger.mp3")
+```
+
+This creates a new [DjmdContent] instance and adds it to the [djmdContent-table]. This
+track will appear in your rekordbox collection, but the track metadata (title, artist,
+etc.) will be blank. To load this data, simply right click the track and select the
+`Reload Tag` menu option. rekordbox will correctly populate the metadata, including
+creating any related table data for things like artist and album.
+
+The `db.add_content()` method accepts `**kwargs` which are passed on to the [DjmdContent]
+instance. You can use these keyword arguments if you want to populate some of the track
+metadata right away. However, things like [DjmdArtist] and [DjmdAlbum] are foreign keys to
+other tables, so make sure you create these objects first and pass the objects via kwargs,
+rather than passing plain strings. A plain string will work for `Title`, however.
+
+```python
+db.add_content("/Users/deadmau5/Downloads/Banger.mp3", Title="Banger")
+```
+
+Populating the [DjmdContent] metadata directly from the track file is not currently
+supported, but it will hopefully be included in a future release.
+
+
 ```{note}
 More coming soon!
 ```

--- a/pyrekordbox/db6/database.py
+++ b/pyrekordbox/db6/database.py
@@ -4,7 +4,6 @@
 
 import datetime
 import logging
-import os
 import secrets
 from uuid import uuid4
 from pathlib import Path
@@ -1908,7 +1907,9 @@ class Rekordbox6Database:
         >>> db.add_content("/Users/foo/Downloads/banger.mp3", Title="Banger")
         <DjmdContent(123456789 Title=Banger)>
         """
-        query = self.query(tables.DjmdContent).filter_by(FolderPath=path)
+        path = Path(path)
+        path_string = str(path)
+        query = self.query(tables.DjmdContent).filter_by(FolderPath=path_string)
         if query.count() > 0:
             raise ValueError(f"Track with path '{path}' already exists in database")
 
@@ -1920,8 +1921,8 @@ class Rekordbox6Database:
         content_link = self.get_menu_items(Name="TRACK").one()
         date_created = datetime.date.today()
         device = self.get_device().first()
-        file_name_l = os.path.basename(path)
-        file_size = os.stat(path).st_size
+        file_name_l = path.name
+        file_size = path.stat().st_size
 
         content = tables.DjmdContent.create(
             ID=id_,
@@ -1933,7 +1934,7 @@ class Rekordbox6Database:
             FileNameL=file_name_l,
             FileSize=file_size,
             FileType=1,
-            FolderPath=path,
+            FolderPath=path_string,
             HotCueAutoLoad="on",
             MasterDBID=device.MasterDBID,
             MasterSongID=id_,

--- a/pyrekordbox/db6/database.py
+++ b/pyrekordbox/db6/database.py
@@ -1879,13 +1879,17 @@ class Rekordbox6Database:
         self.flush()
         return label
 
-    def add_content(self, path):
+    def add_content(self, path, **kwargs):
         """Adds a new track to the database.
 
         Parameters
         ----------
         path : str
             Absolute path to the music file to be added.
+
+        **kwargs:
+            Keyword arguments passed to DjmdContent on creation. These arguments
+            should be a valid DjmdContent field.
 
         Returns
         -------
@@ -1901,8 +1905,8 @@ class Rekordbox6Database:
         Add a new track to the database:
 
         >>> db = Rekordbox6Database()
-        >>> db.add_content(path="/Users/foo/Downloads/banger.mp3")
-        <DjmdContent(123456789 Title=None)>
+        >>> db.add_content("/Users/foo/Downloads/banger.mp3", Title="Banger")
+        <DjmdContent(123456789 Title=Banger)>
         """
         query = self.query(tables.DjmdContent).filter_by(FolderPath=path)
         if query.count() > 0:
@@ -1938,6 +1942,7 @@ class Rekordbox6Database:
             created_at=now,
             updated_at=now,
             rb_file_id=file_id,
+            **kwargs,
         )
         self.add(content)
         self.flush()

--- a/pyrekordbox/db6/database.py
+++ b/pyrekordbox/db6/database.py
@@ -1922,7 +1922,6 @@ class Rekordbox6Database:
         device = self.get_device().first()
         file_name_l = os.path.basename(path)
         file_size = os.stat(path).st_size
-        now = datetime.datetime.now()
 
         content = tables.DjmdContent.create(
             ID=id_,
@@ -1939,8 +1938,6 @@ class Rekordbox6Database:
             MasterDBID=device.MasterDBID,
             MasterSongID=id_,
             StockDate=date_created,
-            created_at=now,
-            updated_at=now,
             rb_file_id=file_id,
             **kwargs,
         )

--- a/pyrekordbox/db6/database.py
+++ b/pyrekordbox/db6/database.py
@@ -17,7 +17,7 @@ from ..config import get_config
 from ..anlz import get_anlz_paths, read_anlz_files, AnlzFile
 from .registry import RekordboxAgentRegistry
 from .aux_files import MasterPlaylistXml
-from .tables import DjmdContent, PlaylistType
+from .tables import DjmdContent, FileType, PlaylistType
 from .smartlist import SmartList
 from . import tables
 
@@ -1898,6 +1898,7 @@ class Rekordbox6Database:
         Raises
         ------
         ValueError : If a track with the same path already exists in the database.
+        ValueError : If the file type is invalid.
 
         Examples
         --------
@@ -1924,6 +1925,12 @@ class Rekordbox6Database:
         file_name_l = path.name
         file_size = path.stat().st_size
 
+        file_type_string = path.suffix.lstrip(".").upper()
+        try:
+            file_type = getattr(FileType, file_type_string)
+        except ValueError:
+            raise ValueError(f"Invalid file type: {path.suffix}")
+
         content = tables.DjmdContent.create(
             ID=id_,
             UUID=uuid,
@@ -1932,7 +1939,7 @@ class Rekordbox6Database:
             DeviceID=device.ID,
             FileNameL=file_name_l,
             FileSize=file_size,
-            FileType=1,
+            FileType=file_type.value,
             FolderPath=path_string,
             HotCueAutoLoad="on",
             MasterDBID=device.MasterDBID,

--- a/pyrekordbox/db6/database.py
+++ b/pyrekordbox/db6/database.py
@@ -1929,7 +1929,6 @@ class Rekordbox6Database:
             UUID=uuid,
             ContentLink=content_link.rb_local_usn,
             DateCreated=date_created,
-            DeliveryControl="on",
             DeviceID=device.ID,
             FileNameL=file_name_l,
             FileSize=file_size,

--- a/pyrekordbox/db6/tables.py
+++ b/pyrekordbox/db6/tables.py
@@ -139,6 +139,14 @@ class PlaylistType(IntEnum):
     SMART_PLAYLIST = 4
 
 
+class FileType(IntEnum):
+    MP3 = 1
+    M4A = 4
+    FLAC = 5
+    WAV = 11
+    AIFF = 12
+
+
 # -- Base- and Mixin classes -----------------------------------------------------------
 
 


### PR DESCRIPTION
This PR adds a method for adding new tracks to the Rekordbox 6 database. It seems to be working on MacOS, but I haven't testetd it on Windows.

The new method doesn't set any of the track metadata information. The new track just shows up in Rekordbox with blank values for Title, Artist, Album, etc. However, Rekordbox is able to pull in all that information (including creating any related data like DjmdArtist) if you right click on the track in rb and select "Reload Tag."

Would you be apposed to adding `mutagen` as a dependency so we can populate the track metadata when it's created by `pyrekordbox`?

I'm also still not 100% sure about the `ContentLink` value. It seems to be a reference to the `rb_local_usn` from the `TRACK` DjmdMenuItem. That value matches for new tracks that I add manually to Rekordbox, but there are older tracks in my library with a `ContentLink` value that doesn't seem to point to anything.

Once this functionality is finalized and approved I'll update the relevant documentation.