### PR TITLE
Fix: root logging level is set as loging.NOSET as part of library initialisation. #128 

### DIFF
--- a/pyrekordbox/logger.py
+++ b/pyrekordbox/logger.py
@@ -20,4 +20,3 @@ logger.addHandler(sh)
 
 # Set logging level
 logger.setLevel(logging.WARNING)
-logging.root.setLevel(logging.NOTSET)


### PR DESCRIPTION
Fix for logging level set for initiazation 

Closes #128
