### PR TITLE
Change 'u1' from Const to Int32ub in Struct

### DIFF
--- a/pyrekordbox/anlz/structs.py
+++ b/pyrekordbox/anlz/structs.py
@@ -42,7 +42,7 @@ AnlzQuantizeTick2 = Struct(
 # len_header: 56
 PQT2 = Struct(
     Padding(4), # -> 16
-    "u1" / Int32ub,  # -> 20, observed values: 0x01000002, 0x02000002 (possibly version indicator)
+    "u1" / Const(0x01000002, Int32ub),  # -> 20, count of "bpm" objects?
     Padding(4), # -> 24
     "bpm" / Array(2, AnlzQuantizeTick),  # -> 40 (2 * 8 bytes = 16 bytes)
     "entry_count" / Int32ub,  # -> 44 number of entries of 2 bytes

--- a/pyrekordbox/anlz/structs.py
+++ b/pyrekordbox/anlz/structs.py
@@ -42,7 +42,7 @@ AnlzQuantizeTick2 = Struct(
 # len_header: 56
 PQT2 = Struct(
     Padding(4), # -> 16
-    "u1" / Const(0x01000002, Int32ub),  # -> 20, count of "bpm" objects?
+    "u1" / Int32ub,  # -> 20, observed values: 0x01000002, 0x02000002 (possibly version indicator)
     Padding(4), # -> 24
     "bpm" / Array(2, AnlzQuantizeTick),  # -> 40 (2 * 8 bytes = 16 bytes)
     "entry_count" / Int32ub,  # -> 44 number of entries of 2 bytes

--- a/pyrekordbox/anlz/structs.py
+++ b/pyrekordbox/anlz/structs.py
@@ -42,7 +42,7 @@ AnlzQuantizeTick2 = Struct(
 # len_header: 56
 PQT2 = Struct(
     Padding(4), # -> 16
-    "u1" / Const(0x01000002, Int32ub),  # -> 20, count of "bpm" objects?
+    "u1" / Int32ub,  # -> 20, observed values: 0x01000002, 0x02000002 (possibly version number)
     Padding(4), # -> 24
     "bpm" / Array(2, AnlzQuantizeTick),  # -> 40 (2 * 8 bytes = 16 bytes)
     "entry_count" / Int32ub,  # -> 44 number of entries of 2 bytes


### PR DESCRIPTION
Rekordbox v7.2.8.0327 creates analysis files with 0x02000002, so the Const(0x01000002, Int32ub) was generating parsing errors. This fix allows for any value in the u1 field.