### PR TITLE
fix(db): ArtistID not checked when adding album

### DIFF
--- a/pyrekordbox/masterdb/database.py
+++ b/pyrekordbox/masterdb/database.py
@@ -1693,11 +1693,6 @@ class MasterDatabase:
         ...     album = db.add_album(name=name)
         >>> content.AlbumID = album.ID
         """
-        # Check if album already exists
-        query = self.query(models.DjmdAlbum).filter_by(Name=name)
-        if query.count() > 0:
-            raise ValueError(f"Album '{name}' already exists in database")
-
         # Get artist ID
         artist_id: Optional[str] = None
         if artist is not None:
@@ -1707,6 +1702,14 @@ class MasterDatabase:
             else:
                 art = artist
             artist_id = art.ID
+
+        # Check if album already exists
+        if artist_id:
+            query = self.query(models.DjmdAlbum).filter_by(Name=name, AlbumArtistID=artist_id)
+        else:
+            query = self.query(models.DjmdAlbum).filter_by(Name=name)
+        if query.count() > 0:
+            raise ValueError(f"Album '{name}' already exists in database")
 
         id_ = self.generate_unused_id(models.DjmdAlbum)
         uuid = str(uuid4())


### PR DESCRIPTION
If an artist is specified as argument when adding album, it will be used to check album name duplication

Closes #195 