### PR TITLE
fix(rbxml): return None from get_track when track is not found

### DIFF
--- a/pyrekordbox/rbxml.py
+++ b/pyrekordbox/rbxml.py
@@ -1165,6 +1165,8 @@ class RekordboxXml:
             el = self._collection.find(f".//{Track.TAG}[{index + 1}]")
         else:
             raise ValueError("Either index, TrackID or Location has to be specified!")
+        if el is None:
+            return None
         return Track(element=el)
 
     def get_track_ids(self) -> List[int]:

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -574,6 +574,10 @@ def test_get_track():
     assert track.Location == expected_loc
     assert track.TrackID == expected_id
 
+    # Missing tracks return None instead of raising on Track(element=None)
+    assert xml.get_track(TrackID=999999999) is None
+    assert xml.get_track(Location="/does/not/exist") is None
+
 
 def test_get_playlist():
     xml = RekordboxXml(XML5)


### PR DESCRIPTION
Closes #193.

When the requested TrackID, Location, or index doesn't match any element, `get_track` previously called `Track(element=None)`. The `None` then propagated into `ElementTree.SubElement`, where it surfaced as the misleading `TypeError: SubElement() argument 1 must be xml.etree.ElementTree.Element, not None`.

This change returns `None` from `get_track` when the lookup misses, matching the suggestion in the issue, and adds a regression test that exercises both `TrackID` and `Location` lookups for non-existent tracks.