### PR TITLE
fix(db): guard string_to_datetime against non-string input

### DIFF
--- a/pyrekordbox/masterdb/models.py
+++ b/pyrekordbox/masterdb/models.py
@@ -126,7 +126,13 @@ def datetime_to_str(value: datetime) -> str:
     return s
 
 
-def string_to_datetime(value: str) -> datetime:
+def string_to_datetime(value: str) -> Optional[datetime]:
+    # Rekordbox 6 has been observed to store non-string values (e.g. integer 0)
+    # in DateTime columns. Treat any non-string input as a missing value rather
+    # than crashing the entire result-set with `AttributeError: 'int' object has
+    # no attribute 'endswith'` further down.
+    if not isinstance(value, str):
+        return None
     try:
         # Normalize 'Z' (Zulu/UTC) to '+00:00' for fromisoformat compatibility
         if value.endswith("Z"):

--- a/tests/test_masterdb.py
+++ b/tests/test_masterdb.py
@@ -90,6 +90,15 @@ def test_string_to_datetime(s):
     assert dt.tzinfo is None
 
 
+@mark.parametrize("value", [0, None, 12345])
+def test_string_to_datetime_returns_none_for_non_string_input(value):
+    # Rekordbox 6 has been observed to store integer 0 in DateTime columns
+    # (e.g. DjmdAlbum.created_at). Without a type-guard the function would
+    # raise AttributeError on `value.endswith("Z")` and break the entire
+    # query that touched the row.
+    assert string_to_datetime(value) is None
+
+
 @mark.parametrize(
     "name,cls",
     [


### PR DESCRIPTION
## Problem

`pyrekordbox.masterdb.models.string_to_datetime` (also exposed as `pyrekordbox.db6.tables.string_to_datetime` via the back-compat re-export) calls `value.endswith("Z")` without type-guarding `value`. Rekordbox 6 has been observed in the wild to store non-string values (specifically integer `0`) in `DateTime` columns — for example `DjmdAlbum.created_at` / `updated_at`.

When this happens, the function raises `AttributeError: 'int' object has no attribute 'endswith'` at SQLAlchemy result-set materialization time. This is not a recoverable per-row error — a single corrupt row crashes the entire query: `session.query(DjmdAlbum).all()`, `.first()`, etc. all fail.

### Reproduction

```python
>>> from pyrekordbox.masterdb.models import string_to_datetime
>>> string_to_datetime(0)
Traceback (most recent call last):
  ...
AttributeError: 'int' object has no attribute 'endswith'
```

## Fix

Type-guard the function: return `None` for non-string input. This treats malformed `DateTime` columns as "no date" rather than crashing the consuming query.

This is consistent with the existing `DateTime.process_result_value` behavior, which already declares `-> Optional[datetime]` and returns `None` when the raw column value is falsy. The return-type annotation of `string_to_datetime` is widened from `datetime` to `Optional[datetime]` to honestly describe the new `None` return path; the only in-repo caller (`DateTime.process_result_value`) already handles `Optional[datetime]`.

### Before / After

```python
# Before
>>> string_to_datetime(0)
AttributeError: 'int' object has no attribute 'endswith'

# After
>>> string_to_datetime(0)  # returns None — treated as missing value
```

Behavior on valid string input is unchanged. Behavior on empty string `""` is also unchanged (still raises `ValueError` from `datetime.fromisoformat("")`, same as before) — in practice the `DateTime` TypeDecorator's truthy guard at `process_result_value` already short-circuits this path, so the empty-string semantic is irrelevant in production but is preserved here for strict backward-compat.

## Tests

Added `test_string_to_datetime_returns_none_for_non_string_input` in `tests/test_masterdb.py`, parametrized over `0`, `None`, and a larger integer. The test fails on `master` (raises `AttributeError`) and passes with this patch.

## Scope

Limited to `pyrekordbox/masterdb/models.py`. **Side-find:** `pyrekordbox/devicelib_plus/models.py` has a byte-identical `string_to_datetime` with the same vulnerability. I kept it out of this PR to keep the review focused, but happy to extend the PR or open a parallel one — whichever you prefer.

## Backward compatibility

- Valid ISO string inputs: behavior unchanged.
- Empty string: behavior unchanged (still raises `ValueError`).
- Non-string inputs (`int`, `None`, ...): previously crashed, now return `None`.
- Return type widens from `datetime` to `Optional[datetime]`. The only in-repo caller already handles `Optional[datetime]`; external callers that rely on a non-None return for non-string inputs were already encountering `AttributeError`, so this is a strict improvement.