### PR TITLE
fix(anlz): avoid infinite recursion in AnlzFile.__len__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Improvements/Bug Fixes
 
+- **anlz:** **fix infinite recursion in ``AnlzFile.__len__``**  
+  ``len(file)`` and ``list(file.keys())`` raised ``RecursionError`` on any ANLZ
+  file (even an empty ``AnlzFile``) because ``__len__`` delegated to ``keys()``,
+  whose ``abc.Mapping`` ``KeysView.__len__`` called back into ``__len__``.
+  ``__len__`` now counts distinct tag types directly, matching ``__iter__``.
 - **db:** **rename the master db handler and update related references**  
   The Rekordbox ``master.db`` handler is renamed to better reflect Rekordbox 6 and 7 support. Renaming includes the package name and the database handler class.
   

--- a/pyrekordbox/anlz/file.py
+++ b/pyrekordbox/anlz/file.py
@@ -210,7 +210,10 @@ class AnlzFile(abc.Mapping):  # type: ignore[type-arg]
         return [tag.get() for tag in self.__getitem__(key)]
 
     def __len__(self) -> int:
-        return len(self.keys())
+        # Count distinct tag types directly. Delegating to ``keys()`` recurses:
+        # ``keys()`` comes from ``abc.Mapping`` and returns a ``KeysView`` whose
+        # ``__len__`` calls back into this method (consistent with ``__iter__``).
+        return len(set(tag.type for tag in self.tags))
 
     def __iter__(self) -> Iterator[str]:
         return iter(set(tag.type for tag in self.tags))

--- a/tests/test_anlz.py
+++ b/tests/test_anlz.py
@@ -37,6 +37,23 @@ def test_read_anlz_files():
         assert len(files) == len(anlz_files)
 
 
+def test_len_and_keys_do_not_recurse():
+    # Regression: AnlzFile.__len__ returned len(self.keys()), but keys() comes
+    # from the abc.Mapping base and returns a KeysView whose __len__ delegates
+    # back to AnlzFile.__len__, so len(file)/list(file.keys()) recursed until
+    # RecursionError on any AnlzFile (even an empty one).
+    file = anlz.AnlzFile()
+    assert len(file) == 0
+    assert list(file.keys()) == []
+
+
+@pytest.mark.parametrize("paths", ANLZ_FILES)
+def test_len_matches_distinct_tag_types(paths):
+    file = anlz.AnlzFile.parse_file(paths["DAT"])
+    assert len(file) == len(list(file.keys()))
+    assert len(file) == len(set(file.tag_types))
+
+
 # -- Tags ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`AnlzFile` subclasses `abc.Mapping` and implements:

```python
def __len__(self) -> int:
    return len(self.keys())
```

But `keys()` is provided by `abc.Mapping` and returns a `KeysView` bound to the file, whose `__len__` calls `len(self._mapping)` -> back into `AnlzFile.__len__`. So `len(file)` recurses until `RecursionError`. This also breaks `list(file.keys())`, because CPython's `list()` calls `__len__` on the view as a length hint.

It reproduces on **any** ANLZ file, including an empty instance:

```python
>>> from pyrekordbox.anlz import AnlzFile
>>> len(AnlzFile())
RecursionError: maximum recursion depth exceeded
```

Raising `sys.setrecursionlimit()` doesn't help; it segfaults (the overflow is in the C-level ABC view machinery).

## Fix

Count distinct tag types directly, consistent with `__iter__` (which already does `iter(set(tag.type for tag in self.tags))`):

```python
def __len__(self) -> int:
    return len(set(tag.type for tag in self.tags))
```

After the fix, the `Mapping` API works as expected:

```python
>>> f = AnlzFile.parse_file("ANLZ0000.DAT")
>>> len(f), list(f.keys())
(6, ['PPTH', 'PVBR', 'PQTZ', 'PWAV', 'PWV2', 'PCOB'])
```

## Tests

- `test_len_and_keys_do_not_recurse` - self-contained reproduction on an empty `AnlzFile` (no test data needed).
- `test_len_matches_distinct_tag_types` - parametrized over the bundled ANLZ test files; asserts `len(file) == len(list(file.keys())) == len(set(file.tag_types))`.

Both fail with `RecursionError` before the change and pass after. The full `tests/test_anlz.py` suite passes (60 tests). CHANGELOG updated under `[Unreleased]`.

Found while validating generated ANLZ files against pyrekordbox.